### PR TITLE
Slice

### DIFF
--- a/src/DataViews.jl
+++ b/src/DataViews.jl
@@ -27,7 +27,9 @@ export
 
     AbstractDataView,
     DataView,
+    index,
     data,
+    components,
 
     AbstractDataSource,
     SQLDataSource,

--- a/src/cache/datacache.jl
+++ b/src/cache/datacache.jl
@@ -36,5 +36,8 @@ data(cache::DataCache) = cache.data
 "`sub(cache::DataCache, idx::Base.ViewIndex...)` builds a new DataCache with subarray of `data`"
 Base.sub(cache::DataCache, idx::Base.ViewIndex...) = DataCache(sub(data(cache), idx...))
 
+"`slice(cache::DataCache, idx::Base.ViewIndex...)` builds a new DataCache with a slice of `data`"
+Base.slice(cache::DataCache, idx::Base.ViewIndex...) = DataCache(slice(data(cache), idx...))
+
 "`setindex!(cache::DataCache, x::Any, idx::Int...` sets the index in the `data` of the DataCache"
 Base.setindex!(cache::DataCache, x::Any, idx::Int...) = data(cache)[idx...] = x

--- a/src/cache/statscache.jl
+++ b/src/cache/statscache.jl
@@ -34,12 +34,27 @@ data(cache::StatsCache) = cache.data
 "`sub(cache::StatsCache, idx::Base.ViewIndex...)` builds a new StatsCache with subarray of `data`"
 Base.sub(cache::StatsCache, idx::Base.ViewIndex...) = StatsCache(sub(data(cache), idx...), cache.stats_dim)
 
+"`slice(cache::StatsCache, idx::Base.ViewIndex...)` builds a new StatsCache with subarray of
+`data`, but drops any dimensions of length 1"
+function Base.slice(cache::StatsCache, idx::Base.ViewIndex...)
+    # Set the stats_dim to -1 if slice has dropped that dimension to avoid
+    # breaking our subcache.
+    stats_dim = -1
+    if (cache.stats_dim >= 1 && length(idx) < stats_dim
+        && (isa(idx[cache.stats_dim], Colon) || length(idx[cache.stats_dim]) > 1))
+
+        stats_dim = cache.stats_dim
+    end
+
+    sliced = slice(data(cache), idx...)
+    StatsCache(sliced, stats_dim)
+end
 """
 `setindex!(cache::DataCache, x::Any, idx::Int...` copies the previous element
 along the `stats_dim` if there is one and calls `update!` with `x` at location `idx`.
 """
 function Base.setindex!(cache::StatsCache, x::Any, idx::Int...)
-    if idx[cache.stats_dim] > 1
+    if cache.stats_dim != -1 && idx[cache.stats_dim] > 1
         prev_idx = [idx...]
         prev_idx[cache.stats_dim] -= 1
         data(cache)[idx...] = copy(data(cache)[prev_idx...])

--- a/src/cache/versioncache.jl
+++ b/src/cache/versioncache.jl
@@ -75,3 +75,22 @@ function Base.sub{T,N}(cache::VersionCache{T,N}, idx::Base.ViewIndex...)
         cache.version_dim
     )
 end
+
+"""
+`slice(cache::VersionCache, idx::Base.ViewIndex...)` builds
+a new VersionCache with slice of `data`, just like `sub`
+
+NOTE: currently the PersistentArray doesn't provide its own `slice`
+that handles subarrays of the versions per element so for now we are just
+ignoring any sub index specified for the version_dim.
+"""
+function Base.slice{T,N}(cache::VersionCache{T,N}, idx::Base.ViewIndex...)
+    array_idx = idx[[setdiff(1:length(idx), cache.version_dim)...]]
+    VersionCache{T,N}(
+        slice(
+            data(cache),
+            array_idx...
+        ),
+        cache.version_dim
+    )
+end

--- a/src/views.jl
+++ b/src/views.jl
@@ -274,7 +274,7 @@ end
 
 
 """
-`getindex(view::DataView, label::Symbol)` provides a mechanism for querying the
+`index(view::DataView, label::Symbol)` provides a mechanism for querying the
 `DataView` for its indices by label. NOTE: All labels are stored as Symbols.
 """
 function index(view::DataView, labels::Vararg{Symbol})
@@ -298,7 +298,7 @@ components(view::DataView) = view.index, view.cache
 Base.insert!(view::AbstractDataView, x::Any) = error("Not Implemented")
 Base.getindex(view::AbstractDataView, idx...) = error("Not Implemented")
 Base.setindex!(view::AbstractDataView, x::Any, idx...) = error("Not Implemented")
-data(view::AbstractDataView, labels::Vararg{Symbol}) = error("Not Implemeneted")
+index(view::AbstractDataView, labels::Vararg{Symbol}) = error("Not Implemeneted")
 data(view::AbstractDataView) = error("Not Implemeneted")
 components(view::AbstractDataView) = error("Not Implemeneted")
 

--- a/src/views.jl
+++ b/src/views.jl
@@ -199,11 +199,50 @@ using the expected keys to determine the determine the element(s) to
 set in the cache.
 """
 function Base.setindex!(view::DataView, x::Any, i...)
-    idx = convert_partitions(i)
+    idx = convert_partitions(pad(view, i))
     index = indices(view, idx...)
     view.cache[index...] = x
 end
 
+Base.getindex(view::DataView, i...) = slice(view, i...)
+
+function Base.slice(view::DataView, i...)
+    idx = convert_partitions(pad(view, i))
+    index = indices(view, idx...)
+
+    sliced = slice(view.cache, index...)
+
+    if length(sliced) == 1
+        return sliced[1]
+    else
+        idx_vals = collect(values(view.index))
+        idx_keys = collect(keys(view.index))
+
+        # Handle what was dropped by the slice
+        new_idx = Any[]
+        new_index = Any[]
+        new_idx_vals = Any[]
+        new_idx_keys = Any[]
+
+        for j in eachindex(index)
+            if (isa(index[j], Colon) ||
+                (isa(index[j], AbstractArray) && length(index[j]) > 1))
+                push!(new_idx, idx[j])
+                push!(new_index, index[j])
+                push!(new_idx_vals, idx_vals[j])
+                push!(new_idx_keys, idx_keys[j])
+            end
+        end
+
+        new_exp = reindex(new_idx_vals, new_index, new_idx)
+
+        return DataView(
+            tuple(new_exp...),
+            sliced;
+            labels=(new_idx_keys...)
+        )
+    end
+end
 
 """
 `getindex(view::DataView, idx...)` performs array style indexing on the
@@ -211,8 +250,8 @@ end
 from a sub cache rather than a copy of it. Also, if the subcache contains a
 single value then that value will be returned rather than a new DataView.
 """
-function Base.getindex(view::DataView, i...)
-    idx = convert_partitions(i)
+function Base.sub(view::DataView, i...)
+    idx = convert_partitions(pad(view, i))
     index = indices(view, idx...)
 
     subcache = sub(view.cache, index...)
@@ -223,51 +262,7 @@ function Base.getindex(view::DataView, i...)
         return subcache[1]
     else
         idx_vals = collect(values(view.index))
-        new_exp = Any[]
-
-        for i in eachindex(index)
-            if isa(idx_vals[i], Associative)
-                sub_dict = OrderedDict()
-                if isa(idx[i], Tuple{Vararg{Symbol}}) || isa(idx[i], Symbol)
-                    tmp_idx = idx[i]
-                    if isa(idx[i], Symbol)
-                        tmp_idx = (idx[i],)
-                    end
-
-                    for key in tmp_idx
-                        sub_dict[key] = idx_vals[i][key]
-                    end
-                elseif isa(idx[i], Associative)
-                    for key in keys(idx[i])
-                        sub_dict[key] = idx_vals[i][key][idx[i][key]]
-                    end
-                elseif isa(idx[i], AbstractArray)
-                    count = 1
-                    all_found = Any[]
-                    for key in keys(idx_vals[i])
-                        start_idx = count
-                        end_idx = count + 1
-                        val = idx_vals[i][key]
-
-                        if isa(val, AbstractArray)
-                            end_idx = count + length(val)
-                        end
-                        count = end_idx
-
-                        found = findin(start_idx:end_idx, idx[i])
-                        if length(found) > 0
-                            sub_dict[key] = found
-                            push!(all_found, found...)
-                        end
-                    end
-
-                    @assert Set(all_found) == Set(idx[i])
-                end
-                push!(new_exp, sub_dict)
-            else
-                push!(new_exp, idx_vals[i][index[i]])
-            end
-        end
+        new_exp = reindex(idx_vals, index, idx)
 
         return DataView(
             tuple(new_exp...),
@@ -282,19 +277,30 @@ end
 `getindex(view::DataView, label::Symbol)` provides a mechanism for querying the
 `DataView` for its indices by label. NOTE: All labels are stored as Symbols.
 """
-Base.getindex(view::DataView, label::Symbol) = view.index[label]
+function index(view::DataView, labels::Vararg{Symbol})
+    if length(labels) > 1
+        return tuple(map(i -> view.index[i], labels)...)
+    elseif length(labels) == 1
+        return view.index[labels[1]]
+    else
+        return view.index
+    end
+end
+
+data(view::DataView) = view.cache
 
 """
-`data(view::DataView)` returns the labels, indices and cache as a tuple.
+`raw(view::DataView)` returns the labels, indices and cache as a tuple.
 """
-data(view::DataView) = view.index, view.cache
+components(view::DataView) = view.index, view.cache
 
 
 Base.insert!(view::AbstractDataView, x::Any) = error("Not Implemented")
 Base.getindex(view::AbstractDataView, idx...) = error("Not Implemented")
-Base.getindex(view::AbstractDataView, label::Symbol) = error("Not Implemented")
 Base.setindex!(view::AbstractDataView, x::Any, idx...) = error("Not Implemented")
+data(view::AbstractDataView, labels::Vararg{Symbol}) = error("Not Implemeneted")
 data(view::AbstractDataView) = error("Not Implemeneted")
+components(view::AbstractDataView) = error("Not Implemeneted")
 
 
 function get_cache_dim(index::OrderedDict)
@@ -367,7 +373,7 @@ function build_index(index::OrderedDict)
             # partition and its values
             if length(new_index[key]) == 1
                 new_keys = collect(keys(new_index))
-                new_vals = collect(values(new_index))
+                new_vals = Any[values(new_index)...]
 
                 new_key = collect(keys(new_index[key]))[1]
                 new_val = new_index[key][new_key]
@@ -386,3 +392,70 @@ function build_index(index::OrderedDict)
 
     return new_index
 end
+
+function reindex(expected, sub_indices, idx)
+    new_exp = Any[]
+
+    for i in eachindex(sub_indices)
+        if isa(expected[i], Associative)
+            sub_dict = OrderedDict()
+            if isa(idx[i], Tuple{Vararg{Symbol}}) || isa(idx[i], Symbol)
+                tmp_idx = idx[i]
+                if isa(idx[i], Symbol)
+                    tmp_idx = (idx[i],)
+                end
+
+                for key in tmp_idx
+                    sub_dict[key] = expected[i][key]
+                end
+            elseif isa(idx[i], Associative)
+                for key in keys(idx[i])
+                    sub_dict[key] = expected[i][key][idx[i][key]]
+                end
+            elseif isa(idx[i], AbstractArray)
+                count = 1
+                all_found = Any[]
+                for key in keys(expected[i])
+                    start_idx = count
+                    end_idx = count + 1
+                    val = expected[i][key]
+
+                    if isa(val, AbstractArray)
+                        end_idx = count + length(val)
+                    end
+                    count = end_idx
+
+                    found = findin(start_idx:end_idx, idx[i])
+                    if length(found) > 0
+                        sub_dict[key] = found
+                        push!(all_found, found...)
+                    end
+                end
+
+                @assert Set(all_found) == Set(idx[i])
+            elseif isa(idx[i], Colon)
+                sub_dict = expected[i]
+            end
+
+            push!(new_exp, sub_dict)
+        else
+            push!(new_exp, expected[i][sub_indices[i]])
+        end
+    end
+
+    return new_exp
+end
+
+function pad(view, idx)
+    len_diff = length(view.index) - length(idx)
+
+    if len_diff > 0
+        return vcat(
+            idx...,
+            fill(:, len_diff)...
+        )
+    else
+        return idx
+    end
+end
+

--- a/test/caches.jl
+++ b/test/caches.jl
@@ -16,6 +16,7 @@ default_cache[2,:] = ones(4)
 @test vec(default_cache[2,:]) == vec(ones(4))
 @test isnan(default_cache[1,2])
 @test default_cache[2, :] == data(sub(default_cache, 2, :))
+@test vec(default_cache[2, :]) == data(slice(default_cache, 2, :))
 
 # Test a StatsCache
 stats_cache = DataViews.StatsCache(Variance, 3, 4)
@@ -29,6 +30,7 @@ stats_cache[2,1] = 4.0
 stats_cache[2, :] = ones(4)
 @test map(i -> nobs(stats_cache[2,i]), eachindex(stats_cache[2,:])) == [2, 1, 1, 1]
 @test stats_cache[2,:] == data(sub(stats_cache, 2, :))
+@test vec(stats_cache[2,:]) == data(slice(stats_cache, 2, :))
 
 # Test a VersionCache
 # Should create a 3 x 4 Persistent Array that
@@ -41,4 +43,5 @@ version_cache[1,1,1] = 2.0
 version_cache[4,1,1] = 4.5
 @test version_cache[4,1,1] == 4.5
 sub_ver_cache = sub(version_cache, 2, :, :)
+sliced_ver_cache = slice(version_cache, 2, :, :)
 #@test isa(data(sub_ver_cache), PersistentArray)

--- a/test/views.jl
+++ b/test/views.jl
@@ -8,6 +8,8 @@ bv = BadView()
 @test_throws(ErrorException, bv[:foo])
 @test_throws(ErrorException, insert!(bv, (1,2,3)))
 @test_throws(ErrorException, data(bv))
+@test_throws(ErrorException, index(bv))
+@test_throws(ErrorException, components(bv))
 
 stop = DateTime(now())
 start = stop - Day(10)


### PR DESCRIPTION
Resolves #7 by switching the default `getindex` behaviour to do a `slice` rather than `sub` to provide more intuitive dropping of dimensions when indexing with a scalar. Both `slice` and sub can be called directly. Unfortunately, the behaviour is slightly different than for Arrays as we don't allow dimension flattening by only indexing into some of the dimension and collapsing the remaining. Instead, we choose to pad the index arguments with Colons to maintain the integrity of the view.
